### PR TITLE
Fix a bug that customProtocol not able to be merged into knownProtocol.

### DIFF
--- a/jsanity-0.3.js
+++ b/jsanity-0.3.js
@@ -958,14 +958,17 @@ jSanity = {};
             tw.currentNode = savedCurrentNode;
         }
 
-        function shadowCopy( des ) {
-            if ( !des ) {
+        function shadowCopy( output ) {
+            if ( !output ) {
                 throw "invalid number of parameters. At least one is expected";
+            }
+
+            if ( output.toString() != "[object Object]" ) {
+                throw "Invalid type of parameter";
             }
 
             var i = 0;
             var source = null;
-            var output = {};
 
             for ( ; i < arguments.length; i++ ) {
                 source = arguments[ i ];


### PR DESCRIPTION
The root cause is in shadowCopy, that the first parameter was designed to be the copy target, but current implementation failed to set.
